### PR TITLE
Add Windaria-inspired anime shader effect plugins

### DIFF
--- a/src/engine/ParamSlider.ts
+++ b/src/engine/ParamSlider.ts
@@ -1,0 +1,78 @@
+export interface SliderConfig {
+  label: string;
+  min: number;
+  max: number;
+  value: number;
+  step?: number;
+  onChange: (value: number) => void;
+}
+
+export class ParamSlider {
+  private panel: HTMLDivElement;
+  private sliders: Map<string, HTMLInputElement> = new Map();
+
+  constructor() {
+    this.panel = document.createElement('div');
+    this.panel.style.cssText = [
+      'position:fixed',
+      'bottom:16px',
+      'right:16px',
+      'z-index:20',
+      'background:rgba(0,0,0,0.7)',
+      'backdrop-filter:blur(8px)',
+      'border-radius:10px',
+      'padding:12px 16px',
+      'font-family:system-ui,sans-serif',
+      'font-size:12px',
+      'color:#eee',
+      'min-width:200px',
+      'user-select:none',
+    ].join(';');
+    document.body.appendChild(this.panel);
+  }
+
+  addSlider(config: SliderConfig): number {
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;align-items:center;gap:8px;margin-bottom:6px;';
+
+    const label = document.createElement('span');
+    label.textContent = config.label;
+    label.style.cssText = 'flex:0 0 90px;text-align:right;opacity:0.8;';
+
+    const input = document.createElement('input');
+    input.type = 'range';
+    input.min = String(config.min);
+    input.max = String(config.max);
+    input.step = String(config.step ?? ((config.max - config.min) / 200));
+    input.value = String(config.value);
+    input.style.cssText = 'flex:1;accent-color:#8af;height:4px;cursor:pointer;';
+
+    const valueLabel = document.createElement('span');
+    valueLabel.textContent = config.value.toFixed(2);
+    valueLabel.style.cssText = 'flex:0 0 42px;text-align:left;font-variant-numeric:tabular-nums;opacity:0.6;';
+
+    input.addEventListener('input', () => {
+      const v = parseFloat(input.value);
+      valueLabel.textContent = v.toFixed(2);
+      config.onChange(v);
+    });
+
+    row.appendChild(label);
+    row.appendChild(input);
+    row.appendChild(valueLabel);
+    this.panel.appendChild(row);
+    this.sliders.set(config.label, input);
+
+    return config.value;
+  }
+
+  getValue(label: string): number {
+    const input = this.sliders.get(label);
+    return input ? parseFloat(input.value) : 0;
+  }
+
+  destroy() {
+    this.panel.remove();
+    this.sliders.clear();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,17 @@ import { Plugin } from './plugin/Plugin';
 import { WobbyCellsPlugin } from './plugins/wobbly-cells';
 import { TuringPatternsPlugin } from './plugins/turing-patterns';
 import { BubblePhysicsPlugin } from './plugins/bubble-physics';
+import { RippleDropPlugin } from './plugins/ripple-drop';
+import { LaserBirdPlugin } from './plugins/laser-bird';
+import { BoatWakePlugin } from './plugins/boat-wake';
 
 const PLUGINS: Record<string, () => Plugin> = {
   'wobbly-cells': () => new WobbyCellsPlugin(),
   'turing-patterns': () => new TuringPatternsPlugin(),
   'bubble-physics': () => new BubblePhysicsPlugin(),
+  'ripple-drop': () => new RippleDropPlugin(),
+  'laser-bird': () => new LaserBirdPlugin(),
+  'boat-wake': () => new BoatWakePlugin(),
 };
 
 const engine = new Engine();

--- a/src/plugins/anime-shaders/REFERENCE.md
+++ b/src/plugins/anime-shaders/REFERENCE.md
@@ -1,0 +1,129 @@
+# Anime Shader Effects — Windaria-Inspired Reference
+
+## 80s Anime Production Context
+
+### Cel Animation Pipeline
+- **Hand-painted cels on acetate**: each frame is gouache/acrylic paint on clear celluloid, layered over painted backgrounds
+- **Limited animation economy**: key poses held for 2–3 frames (12fps or 8fps on 24fps film), with held cels and camera moves substituting for full animation
+- **Multi-layer compositing**: physical cels stacked under a downshooter camera; glows and special effects achieved via multi-exposure, diffusion filters, and airbrush overlays
+- **Studios**: Kaname Pro (Windaria background art), Gallop/Idol (animation production)
+
+### Optical Effects Techniques
+- **Diffusion filters**: glass or gauze filters placed on the camera lens to create soft bloom around bright areas
+- **Multi-exposure compositing**: the same frame of film exposed multiple times with different cel layers/filters to build up glow effects
+- **Airbrush overlays**: separate cels airbrushed with gradient glow patterns, composited over character/effect layers
+- **Backlit cels**: light projected through painted translucent areas for intense glow effects (lasers, magic, explosions)
+
+## Water Ripple Physics & Stylization
+
+### Real Physics
+- Circular wave propagation from a point disturbance
+- Amplitude decays as **1/√r** (energy spreading over expanding circumference)
+- Phase velocity depends on wavelength (dispersion): deep-water waves travel at v = √(gλ/2π)
+- Real ripples produce a continuous spectrum of rings with varying spacing
+
+### Anime Simplification
+- **2–4 discrete rings** instead of continuous wave field
+- White/bright highlights on dark water surface
+- **Intentional gaps** in rings for hand-drawn quality
+- **Thickness variation** along ring circumference suggesting perspective foreshortening
+- Rings may have slight irregularity (not perfect circles)
+- Color: deep blue-black water with white/pale blue ring strokes
+
+### Shader Mapping
+| Visual Quality | GLSL Technique |
+|---|---|
+| Discrete rings | Wave equation heightfield → peak detection |
+| Hand-drawn gaps | Noise-modulated break mask in `inkStroke()` |
+| Thickness variation | Noise-driven width parameter + angular variation |
+| Amplitude decay | Natural 2D wave equation falloff + damping term |
+| Dark water | Low-saturation deep blue base color |
+
+## Ocean/Wake Fluid Dynamics & Stylization
+
+### Real Physics: Kelvin Wake
+- A boat moving at constant speed creates a wake pattern bounded by a **19.47° half-angle** envelope (the Kelvin angle)
+- Inside the envelope: transverse waves (perpendicular to boat heading) and divergent waves (angled outward)
+- Turbulent foam forms along the wake edges and in the recirculation zone behind the boat
+- Wake width grows linearly with distance behind the boat
+
+### Ukiyo-e Wave Influence
+- **Hokusai / ukiyo-e wave aesthetics**: bold black outlines, flat interior color, curling crest motifs
+- Waves depicted as stylized spiral/curl shapes rather than realistic fluid
+- Strong contrast between wave body (deep blue/teal) and foam (white)
+- Repetitive, rhythmic wave patterns creating decorative quality
+
+### Shader Mapping
+| Visual Quality | GLSL Technique |
+|---|---|
+| Kelvin wake envelope | Angular mask based on boat heading ± 19.5° |
+| Foam accumulation | Advection-diffusion simulation on PingPongFBO |
+| Curling wave shapes | Warped domain noise (curl noise) |
+| Bold outlines | Gradient magnitude → `inkStroke()` edge detection |
+| Flat color regions | Step/posterize on foam density |
+| Turbulence | Multi-octave fBm in wake region |
+
+## Glow/Bloom Optical Effects
+
+### Real Optics
+- **Lens bloom**: bright light sources scatter within camera lens elements, creating soft halos
+- **Atmospheric scatter**: particles in air diffuse light from bright sources
+- **Diffraction spikes**: from lens aperture blades (not typically in anime style)
+
+### 80s Anime Technique
+- Multi-exposure compositing with **diffusion-filtered layers**
+- Airbrushed glow cels: hand-painted gradient falloff on separate overlay cels
+- Color temperature shift: glow fringes shift toward warm pink/orange or cool blue
+- Often **2–3 glow layers** of different radii composited additively
+- Extremely saturated core color that desaturates toward edges
+
+### Shader Mapping
+| Visual Quality | GLSL Technique |
+|---|---|
+| Soft bloom | Multi-pass separable Gaussian blur on half-res FBO |
+| Additive compositing | `gl.blendFunc(ONE, ONE)` or shader additive mix |
+| Color temperature shift | Hue rotation in composite pass at glow fringe |
+| Saturated core | Source shape rendered with high-saturation color |
+| Multiple glow radii | Multiple blur passes with different kernel sizes |
+
+## Color Palettes
+
+### Windaria Characteristics
+- **Limited but rich palette**: 20–30 colors per scene typical of hand-painted cels
+- **Strong darks**: deep blues, blacks, and dark teals for night scenes
+- **Saturated highlights**: bright magentas, cyans, golds against dark backgrounds
+- **Warm/cool contrast**: warm skin tones and glows against cool blue-green environments
+
+### Per-Demo Palettes
+- **Water Ripple**: deep navy (#0a0e2a) base, pale blue-white (#c8deff) strokes, subtle teal undertone
+- **Laser Bird**: night sky (#050818), magenta core (#ff3ca0), pink bloom (#ff80c0), warm fringe (#ffa060), starfield whites
+- **Boat Wake**: teal water (#1a4a5a), deep blue (#0d2840), white foam (#e8f0ff), bold outline (#1a2a3a)
+
+## Particle / Petal Effects
+
+### 80s Anime Particles
+- Simple billboard sprites with soft radial falloff
+- Slow drift physics: gentle gravity + random lateral motion
+- Often used for: sakura petals, sparks, magical particles, dust motes
+- Size variation creates depth illusion
+- Opacity fade-in/fade-out over particle lifetime
+
+### Shader Mapping
+- CPU-side particle state (position, velocity, lifetime)
+- Rendered as soft radial points in fragment shader: `exp(-r² * sharpness)`
+- Per-particle color and opacity passed as uniforms or packed into texture
+
+## Mapping Phenomena to Shader Techniques — Summary
+
+| Phenomenon | Source | Shader Technique |
+|---|---|---|
+| Hand-drawn stroke quality | Cel painting | Noise-modulated SDF stroke with breaks |
+| Diffusion glow | Camera filter | Multi-pass Gaussian blur + additive blend |
+| Flat color areas | Gouache paint | Step functions / posterization |
+| Wave propagation | Water physics | 2D wave equation on PingPongFBO |
+| Wake pattern | Kelvin envelope | Angular foam emission mask |
+| Foam dynamics | Fluid turbulence | Advection-diffusion + curl noise |
+| Bloom halo | Multi-exposure | Downsample → blur → composite |
+| Floating particles | Airbrushed overlay | CPU state + soft radial fragment shader |
+| Night sky stars | Background painting | Hash-based point field with twinkle |
+| Color richness | Limited cel palette | Careful constant selection + subtle noise |

--- a/src/plugins/boat-wake/display.glsl
+++ b/src/plugins/boat-wake/display.glsl
@@ -1,0 +1,85 @@
+#version 300 es
+precision highp float;
+
+#include "../../shaders/lib/noise.glsl"
+#include "../../shaders/lib/anime-style.glsl"
+
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform sampler2D u_foam;
+uniform vec2 u_resolution;
+uniform float u_time;
+uniform float u_strokeBoldness;
+uniform vec2 u_boatPos;
+
+// ── Constants ───────────────────────────────────────────────────────
+const vec3 WATER_COLOR   = vec3(0.102, 0.290, 0.353);  // #1a4a5a
+const vec3 WATER_DEEP    = vec3(0.051, 0.157, 0.251);  // #0d2840
+const vec3 FOAM_COLOR    = vec3(0.910, 0.941, 1.0);    // #e8f0ff
+const vec3 OUTLINE_COLOR = vec3(0.102, 0.165, 0.227);  // #1a2a3a
+const float CURL_SCALE   = 12.0;
+
+void main() {
+  vec2 texel = 1.0 / u_resolution;
+  float aspect = u_resolution.x / u_resolution.y;
+
+  // Sample foam field
+  float foam = texture(u_foam, v_uv).r;
+
+  // Gradient of foam for edge detection
+  float fL = texture(u_foam, v_uv + vec2(-texel.x, 0.0)).r;
+  float fR = texture(u_foam, v_uv + vec2( texel.x, 0.0)).r;
+  float fU = texture(u_foam, v_uv + vec2(0.0,  texel.y)).r;
+  float fD = texture(u_foam, v_uv + vec2(0.0, -texel.y)).r;
+  vec2 grad = vec2(fR - fL, fU - fD) * 0.5;
+  float gradMag = length(grad);
+
+  // ── Water base ──
+  // Subtle wave pattern
+  float waveNoise = snoise(v_uv * 6.0 + vec2(u_time * 0.08, u_time * 0.03)) * 0.5 + 0.5;
+  float waveNoise2 = snoise(v_uv * 15.0 + vec2(-u_time * 0.05, u_time * 0.06)) * 0.5 + 0.5;
+  vec3 water = mix(WATER_DEEP, WATER_COLOR, waveNoise * 0.6 + 0.2);
+  water += vec3(0.01, 0.02, 0.03) * waveNoise2;
+
+  // ── Foam rendering ──
+  // Bold outlines at foam edges (ukiyo-e style)
+  float edgeSeed = atan(grad.y, grad.x) * 5.0 + length(v_uv - u_boatPos) * 30.0;
+  float edgeStroke = inkStroke(
+    gradMag - 0.02,
+    u_strokeBoldness * 0.02,
+    5.0,
+    edgeSeed
+  );
+  edgeStroke *= smoothstep(0.005, 0.02, gradMag);
+
+  // Interior foam fill (lighter, flat regions)
+  float foamFill = smoothstep(0.15, 0.4, foam);
+
+  // Curling wave shapes from warped noise
+  vec2 warpedUV = v_uv * CURL_SCALE + vec2(
+    snoise(v_uv * 4.0 + u_time * 0.1) * 0.5,
+    snoise(v_uv * 4.0 + 100.0 + u_time * 0.1) * 0.5
+  );
+  float curlPattern = smoothstep(0.3, 0.5, snoise(warpedUV)) * foam;
+
+  // Composite foam
+  vec3 foamRender = mix(water, FOAM_COLOR * 0.8, foamFill * 0.6);
+  foamRender = mix(foamRender, FOAM_COLOR, curlPattern * 0.4);
+
+  // Bold outline
+  foamRender = mix(foamRender, OUTLINE_COLOR, edgeStroke * 0.7);
+
+  // Bright foam highlights
+  float highlight = smoothstep(0.5, 0.8, foam) * 0.3;
+  foamRender += vec3(highlight);
+
+  // ── Boat marker ──
+  float boatDist = length((v_uv - u_boatPos) * vec2(aspect, 1.0));
+  float boatMarker = smoothstep(0.008, 0.004, boatDist);
+  vec3 boatColor = vec3(0.9, 0.85, 0.7);
+
+  vec3 color = mix(foamRender, boatColor, boatMarker);
+
+  fragColor = vec4(color, 1.0);
+}

--- a/src/plugins/boat-wake/index.ts
+++ b/src/plugins/boat-wake/index.ts
@@ -1,0 +1,195 @@
+import { Plugin } from '../../plugin/Plugin';
+import { EngineContext, GestureEvent } from '../../engine/types';
+import { createProgram } from '../../engine/gl-utils';
+import { PingPongFBO } from '../../plugin/PingPongFBO';
+import { ParamSlider } from '../../engine/ParamSlider';
+import quadVert from '../../shaders/fullscreen-quad.vert';
+import wakeSimFrag from './wake-sim.glsl';
+import displayFrag from './display.glsl';
+
+// ── Constants ───────────────────────────────────────────────────────
+const SIM_SCALE = 0.5;
+
+export class BoatWakePlugin implements Plugin {
+  readonly name = 'Boat Wake';
+
+  private simProgram!: WebGLProgram;
+  private displayProgram!: WebGLProgram;
+  private vao!: WebGLVertexArrayObject;
+  private fbo!: PingPongFBO;
+  private sliders!: ParamSlider;
+
+  // Uniforms
+  private simU!: Record<string, WebGLUniformLocation | null>;
+  private dispU!: Record<string, WebGLUniformLocation | null>;
+
+  // Parameters
+  private boatSpeed = 0.5;
+  private foamDecay = 0.985;
+  private curlIntensity = 1.0;
+  private strokeBoldness = 1.0;
+
+  // Boat state
+  private boatPos: [number, number] = [0.5, 0.5];
+  private boatVel: [number, number] = [0, 0];
+  private boatDir: [number, number] = [1, 0];
+  private userControlled = false;
+  private targetPos: [number, number] | null = null;
+
+  // Auto-pilot
+  private autoTime = 0;
+
+  init(ctx: EngineContext) {
+    const { gl } = ctx;
+
+    this.simProgram = createProgram(gl, quadVert, wakeSimFrag);
+    this.displayProgram = createProgram(gl, quadVert, displayFrag);
+    this.vao = gl.createVertexArray()!;
+
+    const simW = Math.floor(ctx.width * SIM_SCALE);
+    const simH = Math.floor(ctx.height * SIM_SCALE);
+    this.fbo = new PingPongFBO(gl, simW, simH);
+
+    this.simU = this.getUniforms(gl, this.simProgram, [
+      'u_prevFoam', 'u_resolution', 'u_boatPos', 'u_boatDir',
+      'u_boatSpeed', 'u_foamDecay', 'u_curlIntensity', 'u_time',
+    ]);
+    this.dispU = this.getUniforms(gl, this.displayProgram, [
+      'u_foam', 'u_resolution', 'u_time', 'u_strokeBoldness', 'u_boatPos',
+    ]);
+
+    this.sliders = new ParamSlider();
+    this.sliders.addSlider({
+      label: 'Boat Speed', min: 0.1, max: 1.5, value: this.boatSpeed,
+      onChange: (v) => { this.boatSpeed = v; },
+    });
+    this.sliders.addSlider({
+      label: 'Foam Decay', min: 0.95, max: 1.0, value: this.foamDecay, step: 0.001,
+      onChange: (v) => { this.foamDecay = v; },
+    });
+    this.sliders.addSlider({
+      label: 'Curl Intensity', min: 0.0, max: 3.0, value: this.curlIntensity,
+      onChange: (v) => { this.curlIntensity = v; },
+    });
+    this.sliders.addSlider({
+      label: 'Stroke Bold', min: 0.2, max: 3.0, value: this.strokeBoldness,
+      onChange: (v) => { this.strokeBoldness = v; },
+    });
+  }
+
+  render(ctx: EngineContext) {
+    const { gl } = ctx;
+    const dt = Math.min(ctx.dt, 0.05);
+
+    this.updateBoat(dt, ctx.time);
+
+    gl.bindVertexArray(this.vao);
+
+    // ── Simulation pass ──
+    gl.useProgram(this.simProgram);
+    this.fbo.bindRead(gl, 0);
+    gl.uniform1i(this.simU.u_prevFoam, 0);
+    gl.uniform2f(this.simU.u_resolution, this.fbo.width, this.fbo.height);
+    gl.uniform2f(this.simU.u_boatPos, this.boatPos[0], this.boatPos[1]);
+    gl.uniform2f(this.simU.u_boatDir, this.boatDir[0], this.boatDir[1]);
+    gl.uniform1f(this.simU.u_boatSpeed, this.boatSpeed);
+    gl.uniform1f(this.simU.u_foamDecay, this.foamDecay);
+    gl.uniform1f(this.simU.u_curlIntensity, this.curlIntensity);
+    gl.uniform1f(this.simU.u_time, ctx.time);
+
+    this.fbo.bindWrite(gl);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+    this.fbo.swap();
+
+    // ── Display pass ──
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.viewport(0, 0, ctx.width, ctx.height);
+
+    gl.useProgram(this.displayProgram);
+    this.fbo.bindRead(gl, 0);
+    gl.uniform1i(this.dispU.u_foam, 0);
+    gl.uniform2f(this.dispU.u_resolution, ctx.width, ctx.height);
+    gl.uniform1f(this.dispU.u_time, ctx.time);
+    gl.uniform1f(this.dispU.u_strokeBoldness, this.strokeBoldness);
+    gl.uniform2f(this.dispU.u_boatPos, this.boatPos[0], this.boatPos[1]);
+
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+  }
+
+  onGesture(_ctx: EngineContext, event: GestureEvent) {
+    if (event.type === 'drag-start' || event.type === 'drag-move') {
+      this.userControlled = true;
+      this.targetPos = [event.pos.x, 1.0 - event.pos.y];
+    } else if (event.type === 'drag-end') {
+      this.userControlled = false;
+      this.targetPos = null;
+    } else if (event.type === 'tap') {
+      this.targetPos = [event.pos.x, 1.0 - event.pos.y];
+      this.userControlled = true;
+      // Release after reaching target
+      setTimeout(() => { this.userControlled = false; this.targetPos = null; }, 2000);
+    }
+  }
+
+  destroy(ctx: EngineContext) {
+    const { gl } = ctx;
+    gl.deleteProgram(this.simProgram);
+    gl.deleteProgram(this.displayProgram);
+    gl.deleteVertexArray(this.vao);
+    this.fbo.destroy(gl);
+    this.sliders.destroy();
+  }
+
+  private updateBoat(dt: number, time: number) {
+    if (this.targetPos) {
+      // Steer toward target
+      const dx = this.targetPos[0] - this.boatPos[0];
+      const dy = this.targetPos[1] - this.boatPos[1];
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist > 0.01) {
+        this.boatDir = [dx / dist, dy / dist];
+        const speed = this.boatSpeed * 0.3;
+        this.boatPos[0] += this.boatDir[0] * speed * dt;
+        this.boatPos[1] += this.boatDir[1] * speed * dt;
+      }
+    } else {
+      // Auto-pilot: gentle S-curve
+      this.autoTime += dt;
+      const t = this.autoTime;
+      const speed = this.boatSpeed * 0.15;
+
+      // S-curve path
+      const pathX = 0.5 + 0.3 * Math.sin(t * 0.3);
+      const pathY = 0.5 + 0.25 * Math.sin(t * 0.2 + 1.0);
+
+      const dx = pathX - this.boatPos[0];
+      const dy = pathY - this.boatPos[1];
+      const dist = Math.sqrt(dx * dx + dy * dy);
+
+      if (dist > 0.001) {
+        this.boatDir = [dx / dist, dy / dist];
+      }
+
+      this.boatPos[0] += this.boatDir[0] * speed * dt;
+      this.boatPos[1] += this.boatDir[1] * speed * dt;
+
+      // Wrap around edges
+      if (this.boatPos[0] < 0.05) this.boatPos[0] = 0.05;
+      if (this.boatPos[0] > 0.95) this.boatPos[0] = 0.95;
+      if (this.boatPos[1] < 0.05) this.boatPos[1] = 0.05;
+      if (this.boatPos[1] > 0.95) this.boatPos[1] = 0.95;
+    }
+  }
+
+  private getUniforms(
+    gl: WebGL2RenderingContext,
+    program: WebGLProgram,
+    names: string[],
+  ): Record<string, WebGLUniformLocation | null> {
+    const out: Record<string, WebGLUniformLocation | null> = {};
+    for (const name of names) {
+      out[name] = gl.getUniformLocation(program, name);
+    }
+    return out;
+  }
+}

--- a/src/plugins/boat-wake/wake-sim.glsl
+++ b/src/plugins/boat-wake/wake-sim.glsl
@@ -1,0 +1,87 @@
+#version 300 es
+precision highp float;
+
+#include "../../shaders/lib/noise.glsl"
+
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform sampler2D u_prevFoam;
+uniform vec2 u_resolution;
+uniform vec2 u_boatPos;      // normalized position
+uniform vec2 u_boatDir;      // normalized heading direction
+uniform float u_boatSpeed;
+uniform float u_foamDecay;
+uniform float u_curlIntensity;
+uniform float u_time;
+
+// ── Constants ───────────────────────────────────────────────────────
+const float WAKE_HALF_ANGLE = 0.34;  // ~19.5 degrees in radians
+const float FOAM_EMIT_RADIUS = 0.03;
+const float DIFFUSION = 0.3;
+const float ADVECTION = 0.5;
+
+void main() {
+  vec2 texel = 1.0 / u_resolution;
+
+  // Read previous foam state
+  float foam = texture(u_prevFoam, v_uv).r;
+
+  // ── Diffusion (blur with neighbors) ──
+  float fL = texture(u_prevFoam, v_uv + vec2(-texel.x, 0.0)).r;
+  float fR = texture(u_prevFoam, v_uv + vec2( texel.x, 0.0)).r;
+  float fU = texture(u_prevFoam, v_uv + vec2(0.0,  texel.y)).r;
+  float fD = texture(u_prevFoam, v_uv + vec2(0.0, -texel.y)).r;
+  float avg = (fL + fR + fU + fD) * 0.25;
+  foam = mix(foam, avg, DIFFUSION * 0.1);
+
+  // ── Advection (foam drifts backward from boat) ──
+  vec2 advectDir = -u_boatDir * ADVECTION * 0.005;
+  // Add curl noise for turbulent advection
+  float n1 = snoise((v_uv + vec2(u_time * 0.05)) * 8.0);
+  float n2 = snoise((v_uv + vec2(0.0, u_time * 0.05)) * 8.0 + 100.0);
+  vec2 curlOffset = vec2(n1, -n2) * u_curlIntensity * 0.002;
+  vec2 samplePos = v_uv - advectDir - curlOffset;
+  float advectedFoam = texture(u_prevFoam, samplePos).r;
+  foam = max(foam, advectedFoam * 0.95);
+
+  // ── Decay ──
+  foam *= u_foamDecay;
+
+  // ── Foam emission in wake envelope ──
+  vec2 toPixel = v_uv - u_boatPos;
+  float distFromBoat = length(toPixel);
+
+  // Project onto boat direction to get distance behind boat
+  float behind = -dot(toPixel, u_boatDir);
+
+  if (behind > 0.0 && distFromBoat > 0.005) {
+    // Perpendicular distance from wake centerline
+    float perpDist = abs(dot(toPixel, vec2(-u_boatDir.y, u_boatDir.x)));
+
+    // Kelvin wake envelope
+    float wakeWidth = behind * tan(WAKE_HALF_ANGLE);
+    float inWake = smoothstep(wakeWidth, wakeWidth * 0.7, perpDist);
+
+    // Foam density: stronger near the V-edges and close to boat
+    float edgeFactor = smoothstep(wakeWidth * 0.3, wakeWidth * 0.8, perpDist);
+    float proximityFactor = exp(-behind * 3.0);
+
+    // Turbulence noise in wake
+    float turbulence = fbm3(v_uv * 20.0 + u_time * 0.3) * 0.5 + 0.5;
+
+    float emission = inWake * (edgeFactor * 0.8 + 0.3) * proximityFactor * u_boatSpeed;
+    emission *= turbulence;
+
+    // Direct foam near boat hull
+    float hullFoam = exp(-distFromBoat * distFromBoat / (FOAM_EMIT_RADIUS * FOAM_EMIT_RADIUS));
+    emission += hullFoam * u_boatSpeed * 2.0;
+
+    foam = max(foam, emission);
+  }
+
+  // Clamp foam
+  foam = clamp(foam, 0.0, 1.0);
+
+  fragColor = vec4(foam, foam, foam, 1.0);
+}

--- a/src/plugins/laser-bird/bird.glsl
+++ b/src/plugins/laser-bird/bird.glsl
@@ -1,0 +1,79 @@
+#version 300 es
+precision highp float;
+
+#include "../../shaders/lib/noise.glsl"
+#include "../../shaders/lib/sdf2d.glsl"
+
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform vec2 u_resolution;
+uniform float u_time;
+uniform vec2 u_birdPos;       // normalized bird center
+uniform float u_wingSpread;   // 0.0–1.0
+
+// ── Constants ───────────────────────────────────────────────────────
+const vec3 CORE_COLOR   = vec3(1.0, 0.235, 0.627);   // #ff3ca0
+const vec3 FRINGE_COLOR = vec3(1.0, 0.502, 0.753);   // #ff80c0
+const float BIRD_SCALE  = 0.12;
+
+// Bird SDF: body ellipse + wing arcs + tail
+float birdSDF(vec2 p, float wingSpread) {
+  // Body: horizontal ellipse
+  vec2 bodyP = p / vec2(1.8, 1.0);
+  float body = sdCircle(bodyP, BIRD_SCALE * 0.5);
+
+  // Head: small circle offset forward
+  float head = sdCircle(p - vec2(BIRD_SCALE * 0.7, BIRD_SCALE * 0.1), BIRD_SCALE * 0.25);
+
+  float bird = opSmoothUnion(body, head, BIRD_SCALE * 0.3);
+
+  // Wings: arcs extending from body, angle controlled by wingSpread
+  float wingAngle = 1.2 + wingSpread * 1.0; // aperture
+  float wingLen = BIRD_SCALE * (1.2 + wingSpread * 0.8);
+
+  // Left wing (top)
+  vec2 lwp = p - vec2(-BIRD_SCALE * 0.2, BIRD_SCALE * 0.15);
+  lwp = vec2(lwp.x * 0.8 - lwp.y * 0.6, lwp.x * 0.6 + lwp.y * 0.8); // rotate
+  float lwing = sdArc(lwp, wingLen, wingAngle) - BIRD_SCALE * 0.08;
+
+  // Right wing (bottom)
+  vec2 rwp = p - vec2(-BIRD_SCALE * 0.2, -BIRD_SCALE * 0.15);
+  rwp = vec2(rwp.x * 0.8 + rwp.y * 0.6, -rwp.x * 0.6 + rwp.y * 0.8);
+  float rwing = sdArc(rwp, wingLen, wingAngle) - BIRD_SCALE * 0.08;
+
+  bird = opSmoothUnion(bird, lwing, BIRD_SCALE * 0.15);
+  bird = opSmoothUnion(bird, rwing, BIRD_SCALE * 0.15);
+
+  // Tail: elongated shape trailing behind
+  vec2 tp = p - vec2(-BIRD_SCALE * 1.0, 0.0);
+  tp /= vec2(2.5, 0.6);
+  float tail = sdCircle(tp, BIRD_SCALE * 0.3);
+  bird = opSmoothUnion(bird, tail, BIRD_SCALE * 0.2);
+
+  return bird;
+}
+
+void main() {
+  vec2 uv = v_uv;
+  float aspect = u_resolution.x / u_resolution.y;
+  vec2 p = (uv - u_birdPos) * vec2(aspect, 1.0);
+
+  float d = birdSDF(p, u_wingSpread);
+
+  // Core shape: saturated magenta
+  float coreMask = smoothstep(0.005, -0.005, d);
+
+  // Inner glow falloff
+  float glow = exp(-max(d, 0.0) * 15.0) * 1.5;
+
+  // Color gradient: core → fringe
+  vec3 color = mix(FRINGE_COLOR, CORE_COLOR, coreMask);
+  float alpha = max(coreMask, glow);
+
+  // Subtle pulsing
+  float pulse = 1.0 + 0.08 * sin(u_time * 2.5);
+  alpha *= pulse;
+
+  fragColor = vec4(color * alpha, alpha);
+}

--- a/src/plugins/laser-bird/blur.glsl
+++ b/src/plugins/laser-bird/blur.glsl
@@ -1,0 +1,27 @@
+#version 300 es
+precision highp float;
+
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform sampler2D u_source;
+uniform vec2 u_direction;   // (1/w, 0) for horizontal, (0, 1/h) for vertical
+uniform float u_glowRadius;
+
+// 15-tap Gaussian kernel (sigma ~4.5)
+const float weights[8] = float[8](
+  0.1353352832, 0.1238315369, 0.0948770038, 0.0607710517,
+  0.0325514671, 0.0145896860, 0.0054679687, 0.0017118080
+);
+
+void main() {
+  vec3 result = texture(u_source, v_uv).rgb * weights[0];
+
+  for (int i = 1; i < 8; i++) {
+    vec2 offset = u_direction * float(i) * u_glowRadius;
+    result += texture(u_source, v_uv + offset).rgb * weights[i];
+    result += texture(u_source, v_uv - offset).rgb * weights[i];
+  }
+
+  fragColor = vec4(result, 1.0);
+}

--- a/src/plugins/laser-bird/composite.glsl
+++ b/src/plugins/laser-bird/composite.glsl
@@ -1,0 +1,98 @@
+#version 300 es
+precision highp float;
+
+#include "../../shaders/lib/noise.glsl"
+
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform sampler2D u_scene;       // bird shape + core glow
+uniform sampler2D u_bloom;       // blurred glow
+uniform vec2 u_resolution;
+uniform float u_time;
+uniform float u_glowIntensity;
+uniform float u_particleDensity;
+
+// ── Constants ───────────────────────────────────────────────────────
+const vec3 SKY_COLOR     = vec3(0.020, 0.031, 0.094);  // #050818
+const vec3 WARM_FRINGE   = vec3(1.0, 0.627, 0.376);    // #ffa060
+const float STAR_DENSITY = 800.0;
+const float COLOR_SHIFT  = 0.15;
+
+// Particle state (passed as uniforms would be complex, so generate procedurally)
+const int MAX_PARTICLES = 40;
+
+void main() {
+  float aspect = u_resolution.x / u_resolution.y;
+
+  // ── Starfield background ──
+  vec2 starUV = v_uv * vec2(aspect, 1.0) * STAR_DENSITY;
+  vec2 starCell = floor(starUV);
+  vec2 starFrac = fract(starUV) - 0.5;
+
+  float starBright = 0.0;
+  // Check this cell and neighbors for stars
+  for (int dy = -1; dy <= 1; dy++) {
+    for (int dx = -1; dx <= 1; dx++) {
+      vec2 cell = starCell + vec2(float(dx), float(dy));
+      vec2 starPos = hash22(cell) - 0.5;
+      float dist = length(starFrac - starPos - vec2(float(dx), float(dy)));
+
+      float h = hash21(cell);
+      if (h > 0.92) { // only ~8% of cells have stars
+        float twinkle = 0.6 + 0.4 * sin(u_time * (1.0 + h * 3.0) + h * 40.0);
+        float brightness = (h - 0.92) / 0.08; // 0..1
+        float star = brightness * twinkle * exp(-dist * dist * 400.0);
+        starBright += star;
+      }
+    }
+  }
+
+  vec3 sky = SKY_COLOR + vec3(starBright * 0.9, starBright * 0.92, starBright);
+
+  // ── Scene + bloom compositing ──
+  vec3 scene = texture(u_scene, v_uv).rgb;
+  vec3 bloom = texture(u_bloom, v_uv).rgb;
+
+  // Color temperature shift at bloom fringe
+  float bloomMag = dot(bloom, vec3(0.299, 0.587, 0.114));
+  vec3 warmBloom = mix(bloom, bloom * WARM_FRINGE, COLOR_SHIFT * smoothstep(0.05, 0.3, bloomMag));
+
+  // Additive composite
+  vec3 color = sky + scene + warmBloom * u_glowIntensity;
+
+  // ── Floating particles ──
+  float particleGlow = 0.0;
+  for (int i = 0; i < MAX_PARTICLES; i++) {
+    if (float(i) >= u_particleDensity * float(MAX_PARTICLES)) break;
+
+    float fi = float(i);
+    float seed = fi * 0.1;
+
+    // Particle position: slow upward drift with lateral wobble
+    float px = 0.3 + 0.4 * hash21(vec2(fi, 0.0));
+    float baseY = fract(hash21(vec2(fi, 1.0)) + u_time * (0.02 + 0.02 * hash21(vec2(fi, 2.0))));
+    float py = baseY;
+    px += sin(u_time * 0.5 + fi * 1.7) * 0.03;
+
+    vec2 pPos = vec2(px, py);
+    float dist = length((v_uv - pPos) * vec2(aspect, 1.0));
+
+    // Soft radial particle
+    float pSize = 0.003 + 0.004 * hash21(vec2(fi, 3.0));
+    float particle = exp(-dist * dist / (pSize * pSize));
+
+    // Fade at top/bottom edges
+    float fade = smoothstep(0.0, 0.1, py) * smoothstep(1.0, 0.9, py);
+    particleGlow += particle * fade * 0.4;
+  }
+
+  // Particles are pinkish-white
+  vec3 particleColor = vec3(1.0, 0.75, 0.85);
+  color += particleColor * particleGlow;
+
+  // Tone mapping (soft clamp)
+  color = color / (1.0 + color * 0.3);
+
+  fragColor = vec4(color, 1.0);
+}

--- a/src/plugins/laser-bird/index.ts
+++ b/src/plugins/laser-bird/index.ts
@@ -1,0 +1,214 @@
+import { Plugin } from '../../plugin/Plugin';
+import { EngineContext, GestureEvent } from '../../engine/types';
+import { createProgram } from '../../engine/gl-utils';
+import { PingPongFBO } from '../../plugin/PingPongFBO';
+import { ParamSlider } from '../../engine/ParamSlider';
+import quadVert from '../../shaders/fullscreen-quad.vert';
+import birdFrag from './bird.glsl';
+import blurFrag from './blur.glsl';
+import compositeFrag from './composite.glsl';
+
+// ── Constants ───────────────────────────────────────────────────────
+const BLOOM_SCALE = 0.5; // bloom FBO at half res
+const BLUR_PASSES = 3;   // number of H+V blur passes
+
+export class LaserBirdPlugin implements Plugin {
+  readonly name = 'Laser Bird';
+
+  private birdProgram!: WebGLProgram;
+  private blurProgram!: WebGLProgram;
+  private compositeProgram!: WebGLProgram;
+  private vao!: WebGLVertexArrayObject;
+
+  // FBOs
+  private sceneFBO!: { fbo: WebGLFramebuffer; tex: WebGLTexture; w: number; h: number };
+  private bloomFBO!: PingPongFBO;
+
+  // Uniforms
+  private birdU!: Record<string, WebGLUniformLocation | null>;
+  private blurU!: Record<string, WebGLUniformLocation | null>;
+  private compU!: Record<string, WebGLUniformLocation | null>;
+
+  // Parameters
+  private glowIntensity = 1.5;
+  private glowRadius = 2.0;
+  private particleDensity = 0.6;
+  private wingSpread = 0.5;
+
+  // Interaction
+  private birdPos: [number, number] = [0.5, 0.5];
+  private sliders!: ParamSlider;
+
+  init(ctx: EngineContext) {
+    const { gl } = ctx;
+
+    this.birdProgram = createProgram(gl, quadVert, birdFrag);
+    this.blurProgram = createProgram(gl, quadVert, blurFrag);
+    this.compositeProgram = createProgram(gl, quadVert, compositeFrag);
+    this.vao = gl.createVertexArray()!;
+
+    // Scene FBO (full res)
+    this.sceneFBO = this.createFBO(gl, ctx.width, ctx.height);
+
+    // Bloom FBO (half res)
+    const bw = Math.floor(ctx.width * BLOOM_SCALE);
+    const bh = Math.floor(ctx.height * BLOOM_SCALE);
+    this.bloomFBO = new PingPongFBO(gl, bw, bh);
+
+    // Cache uniforms
+    this.birdU = this.getUniforms(gl, this.birdProgram, [
+      'u_resolution', 'u_time', 'u_birdPos', 'u_wingSpread',
+    ]);
+    this.blurU = this.getUniforms(gl, this.blurProgram, [
+      'u_source', 'u_direction', 'u_glowRadius',
+    ]);
+    this.compU = this.getUniforms(gl, this.compositeProgram, [
+      'u_scene', 'u_bloom', 'u_resolution', 'u_time',
+      'u_glowIntensity', 'u_particleDensity',
+    ]);
+
+    // Sliders
+    this.sliders = new ParamSlider();
+    this.sliders.addSlider({
+      label: 'Glow Intensity', min: 0.3, max: 4.0, value: this.glowIntensity,
+      onChange: (v) => { this.glowIntensity = v; },
+    });
+    this.sliders.addSlider({
+      label: 'Glow Radius', min: 0.5, max: 5.0, value: this.glowRadius,
+      onChange: (v) => { this.glowRadius = v; },
+    });
+    this.sliders.addSlider({
+      label: 'Particles', min: 0.0, max: 1.0, value: this.particleDensity,
+      onChange: (v) => { this.particleDensity = v; },
+    });
+    this.sliders.addSlider({
+      label: 'Wing Spread', min: 0.0, max: 1.0, value: this.wingSpread,
+      onChange: (v) => { this.wingSpread = v; },
+    });
+  }
+
+  render(ctx: EngineContext) {
+    const { gl } = ctx;
+    gl.bindVertexArray(this.vao);
+
+    // ── Pass 1: Render bird to scene FBO ──
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.sceneFBO.fbo);
+    gl.viewport(0, 0, this.sceneFBO.w, this.sceneFBO.h);
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    gl.useProgram(this.birdProgram);
+    gl.uniform2f(this.birdU.u_resolution, this.sceneFBO.w, this.sceneFBO.h);
+    gl.uniform1f(this.birdU.u_time, ctx.time);
+    gl.uniform2f(this.birdU.u_birdPos, this.birdPos[0], this.birdPos[1]);
+    gl.uniform1f(this.birdU.u_wingSpread, this.wingSpread);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+    // ── Pass 2: Bloom — downsample scene to bloom FBO, then blur ──
+    // First blit scene into bloom FBO as starting point
+    this.bloomFBO.bindWrite(gl);
+    gl.useProgram(this.blurProgram);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.sceneFBO.tex);
+    gl.uniform1i(this.blurU.u_source, 0);
+    gl.uniform2f(this.blurU.u_direction, 0.0, 0.0); // no blur on first pass (just downsample)
+    gl.uniform1f(this.blurU.u_glowRadius, 1.0);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+    this.bloomFBO.swap();
+
+    // Multi-pass separable blur
+    const bw = this.bloomFBO.width;
+    const bh = this.bloomFBO.height;
+    for (let i = 0; i < BLUR_PASSES; i++) {
+      const scale = this.glowRadius * (1.0 + i * 0.5);
+
+      // Horizontal
+      this.bloomFBO.bindRead(gl, 0);
+      gl.uniform1i(this.blurU.u_source, 0);
+      gl.uniform2f(this.blurU.u_direction, scale / bw, 0.0);
+      gl.uniform1f(this.blurU.u_glowRadius, 1.0);
+      this.bloomFBO.bindWrite(gl);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+      this.bloomFBO.swap();
+
+      // Vertical
+      this.bloomFBO.bindRead(gl, 0);
+      gl.uniform1i(this.blurU.u_source, 0);
+      gl.uniform2f(this.blurU.u_direction, 0.0, scale / bh);
+      this.bloomFBO.bindWrite(gl);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+      this.bloomFBO.swap();
+    }
+
+    // ── Pass 3: Composite ──
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.viewport(0, 0, ctx.width, ctx.height);
+
+    gl.useProgram(this.compositeProgram);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.sceneFBO.tex);
+    gl.uniform1i(this.compU.u_scene, 0);
+
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, this.bloomFBO.readTexture);
+    gl.uniform1i(this.compU.u_bloom, 1);
+
+    gl.uniform2f(this.compU.u_resolution, ctx.width, ctx.height);
+    gl.uniform1f(this.compU.u_time, ctx.time);
+    gl.uniform1f(this.compU.u_glowIntensity, this.glowIntensity);
+    gl.uniform1f(this.compU.u_particleDensity, this.particleDensity);
+
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+  }
+
+  onGesture(_ctx: EngineContext, event: GestureEvent) {
+    if (event.type === 'drag-move' || event.type === 'drag-start') {
+      this.birdPos = [event.pos.x, 1.0 - event.pos.y];
+    } else if (event.type === 'tap') {
+      // Pulse effect handled by time-based oscillation already
+      this.birdPos = [event.pos.x, 1.0 - event.pos.y];
+    }
+  }
+
+  destroy(ctx: EngineContext) {
+    const { gl } = ctx;
+    gl.deleteProgram(this.birdProgram);
+    gl.deleteProgram(this.blurProgram);
+    gl.deleteProgram(this.compositeProgram);
+    gl.deleteVertexArray(this.vao);
+    gl.deleteFramebuffer(this.sceneFBO.fbo);
+    gl.deleteTexture(this.sceneFBO.tex);
+    this.bloomFBO.destroy(gl);
+    this.sliders.destroy();
+  }
+
+  private createFBO(gl: WebGL2RenderingContext, w: number, h: number) {
+    gl.getExtension('EXT_color_buffer_float');
+
+    const tex = gl.createTexture()!;
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA16F, w, h, 0, gl.RGBA, gl.HALF_FLOAT, null);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    const fbo = gl.createFramebuffer()!;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+
+    return { fbo, tex, w, h };
+  }
+
+  private getUniforms(
+    gl: WebGL2RenderingContext,
+    program: WebGLProgram,
+    names: string[],
+  ): Record<string, WebGLUniformLocation | null> {
+    const out: Record<string, WebGLUniformLocation | null> = {};
+    for (const name of names) {
+      out[name] = gl.getUniformLocation(program, name);
+    }
+    return out;
+  }
+}

--- a/src/plugins/ripple-drop/display.glsl
+++ b/src/plugins/ripple-drop/display.glsl
@@ -1,0 +1,89 @@
+#version 300 es
+precision highp float;
+
+#include "../../shaders/lib/noise.glsl"
+#include "../../shaders/lib/anime-style.glsl"
+
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform sampler2D u_heightfield;
+uniform vec2 u_resolution;
+uniform float u_time;
+uniform float u_strokeWidth;
+uniform float u_breakFreq;
+
+// ── Constants ───────────────────────────────────────────────────────
+const vec3 WATER_DEEP   = vec3(0.039, 0.055, 0.165);   // #0a0e2a
+const vec3 WATER_MID    = vec3(0.055, 0.082, 0.200);
+const vec3 STROKE_COLOR = vec3(0.784, 0.871, 1.0);      // #c8deff
+const float RING_FADE   = 0.6;
+const float PERSPECTIVE_TILT = 0.15;
+
+void main() {
+  vec2 texel = 1.0 / u_resolution;
+  float aspect = u_resolution.x / u_resolution.y;
+
+  // Sample heightfield
+  float h = texture(u_heightfield, v_uv).r;
+
+  // Gradient of heightfield for edge/ring detection
+  float hL = texture(u_heightfield, v_uv + vec2(-texel.x, 0.0)).r;
+  float hR = texture(u_heightfield, v_uv + vec2( texel.x, 0.0)).r;
+  float hU = texture(u_heightfield, v_uv + vec2(0.0,  texel.y)).r;
+  float hD = texture(u_heightfield, v_uv + vec2(0.0, -texel.y)).r;
+
+  vec2 grad = vec2(hR - hL, hU - hD) * 0.5;
+  float gradMag = length(grad);
+
+  // Ring detection: zero-crossings / peaks of height
+  float dh_dx = hR - hL;
+  float dh_dy = hU - hD;
+  float curvature = abs((hL + hR + hU + hD) - 4.0 * h);
+
+  // Combine gradient magnitude and curvature for ring visibility
+  float ringStrength = smoothstep(0.001, 0.02, gradMag) * smoothstep(0.0, 0.005, curvature);
+
+  // Angle along ring for break pattern
+  float angle = atan(grad.y, grad.x);
+
+  // Perspective foreshortening: make strokes thinner toward top
+  float perspFactor = 1.0 - PERSPECTIVE_TILT * (1.0 - v_uv.y);
+
+  // Ink stroke with hand-drawn breaks
+  float seed = angle * 3.0 + length(v_uv - 0.5) * 20.0;
+  float strokeAlpha = inkStroke(
+    gradMag - 0.01,   // SDF-like distance
+    u_strokeWidth * perspFactor * 0.03,
+    u_breakFreq,
+    seed
+  );
+
+  // Additional ring emphasis from height peaks
+  float peakStroke = smoothstep(0.005, 0.015, abs(h)) * ringStrength;
+  strokeAlpha = max(strokeAlpha * ringStrength, peakStroke * 0.6);
+
+  // Clamp stroke
+  strokeAlpha = clamp(strokeAlpha, 0.0, 1.0);
+
+  // Fade rings with distance from center (amplitude naturally decays)
+  float distFromCenter = length(v_uv - 0.5);
+  float fadeFactor = 1.0 - smoothstep(0.1, RING_FADE, distFromCenter) * 0.5;
+  strokeAlpha *= fadeFactor;
+
+  // Water base color with subtle variation
+  float waterNoise = snoise(v_uv * 8.0 + u_time * 0.1) * 0.03;
+  vec3 waterColor = mix(WATER_DEEP, WATER_MID, v_uv.y * 0.5 + waterNoise);
+
+  // Height-based subtle color shift
+  waterColor += vec3(0.0, 0.01, 0.03) * h * 10.0;
+
+  // Composite stroke over water
+  vec3 color = mix(waterColor, STROKE_COLOR, strokeAlpha);
+
+  // Subtle specular highlight on wave peaks
+  float specular = smoothstep(0.01, 0.03, h) * 0.15;
+  color += vec3(specular);
+
+  fragColor = vec4(color, 1.0);
+}

--- a/src/plugins/ripple-drop/index.ts
+++ b/src/plugins/ripple-drop/index.ts
@@ -1,0 +1,156 @@
+import { Plugin } from '../../plugin/Plugin';
+import { EngineContext, GestureEvent } from '../../engine/types';
+import { createProgram } from '../../engine/gl-utils';
+import { PingPongFBO } from '../../plugin/PingPongFBO';
+import { ParamSlider } from '../../engine/ParamSlider';
+import quadVert from '../../shaders/fullscreen-quad.vert';
+import simulateFrag from './simulate.glsl';
+import displayFrag from './display.glsl';
+
+// ── Constants ───────────────────────────────────────────────────────
+const SIM_SCALE = 0.5; // simulation runs at half resolution
+
+export class RippleDropPlugin implements Plugin {
+  readonly name = 'Ripple Drop';
+
+  private simProgram!: WebGLProgram;
+  private displayProgram!: WebGLProgram;
+  private vao!: WebGLVertexArrayObject;
+  private fbo!: PingPongFBO;
+  private sliders!: ParamSlider;
+
+  // Uniforms
+  private simUniforms!: Record<string, WebGLUniformLocation | null>;
+  private dispUniforms!: Record<string, WebGLUniformLocation | null>;
+
+  // Parameters (live-adjustable)
+  private strokeWidth = 1.0;
+  private breakFreq = 6.0;
+  private damping = 0.995;
+  private waveSpeed = 0.45;
+
+  // Interaction state
+  private pendingImpulse: [number, number] | null = null;
+  private dragging = false;
+  private dragPos: [number, number] = [0, 0];
+
+  init(ctx: EngineContext) {
+    const { gl } = ctx;
+
+    this.simProgram = createProgram(gl, quadVert, simulateFrag);
+    this.displayProgram = createProgram(gl, quadVert, displayFrag);
+    this.vao = gl.createVertexArray()!;
+
+    const simW = Math.floor(ctx.width * SIM_SCALE);
+    const simH = Math.floor(ctx.height * SIM_SCALE);
+    this.fbo = new PingPongFBO(gl, simW, simH);
+
+    // Cache uniform locations
+    this.simUniforms = this.getUniforms(gl, this.simProgram, [
+      'u_prevState', 'u_resolution', 'u_damping', 'u_waveSpeed',
+      'u_impulsePos', 'u_impulseStrength',
+    ]);
+    this.dispUniforms = this.getUniforms(gl, this.displayProgram, [
+      'u_heightfield', 'u_resolution', 'u_time', 'u_strokeWidth', 'u_breakFreq',
+    ]);
+
+    // Slider UI
+    this.sliders = new ParamSlider();
+    this.sliders.addSlider({
+      label: 'Stroke Width', min: 0.2, max: 3.0, value: this.strokeWidth,
+      onChange: (v) => { this.strokeWidth = v; },
+    });
+    this.sliders.addSlider({
+      label: 'Break Freq', min: 1.0, max: 15.0, value: this.breakFreq,
+      onChange: (v) => { this.breakFreq = v; },
+    });
+    this.sliders.addSlider({
+      label: 'Damping', min: 0.98, max: 1.0, value: this.damping, step: 0.001,
+      onChange: (v) => { this.damping = v; },
+    });
+    this.sliders.addSlider({
+      label: 'Wave Speed', min: 0.1, max: 0.8, value: this.waveSpeed,
+      onChange: (v) => { this.waveSpeed = v; },
+    });
+  }
+
+  render(ctx: EngineContext) {
+    const { gl } = ctx;
+
+    // ── Simulation pass ──
+    gl.useProgram(this.simProgram);
+    this.fbo.bindRead(gl, 0);
+    gl.uniform1i(this.simUniforms.u_prevState, 0);
+    gl.uniform2f(this.simUniforms.u_resolution, this.fbo.width, this.fbo.height);
+    gl.uniform1f(this.simUniforms.u_damping, this.damping);
+    gl.uniform1f(this.simUniforms.u_waveSpeed, this.waveSpeed);
+
+    // Handle impulse from click/tap
+    if (this.pendingImpulse) {
+      gl.uniform2f(this.simUniforms.u_impulsePos, this.pendingImpulse[0], this.pendingImpulse[1]);
+      gl.uniform1f(this.simUniforms.u_impulseStrength, 0.5);
+      this.pendingImpulse = null;
+    } else if (this.dragging) {
+      gl.uniform2f(this.simUniforms.u_impulsePos, this.dragPos[0], this.dragPos[1]);
+      gl.uniform1f(this.simUniforms.u_impulseStrength, 0.15);
+    } else {
+      gl.uniform2f(this.simUniforms.u_impulsePos, -1.0, -1.0);
+      gl.uniform1f(this.simUniforms.u_impulseStrength, 0.0);
+    }
+
+    this.fbo.bindWrite(gl);
+    gl.bindVertexArray(this.vao);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+    this.fbo.swap();
+
+    // ── Display pass ──
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.viewport(0, 0, ctx.width, ctx.height);
+    gl.useProgram(this.displayProgram);
+
+    this.fbo.bindRead(gl, 0);
+    gl.uniform1i(this.dispUniforms.u_heightfield, 0);
+    gl.uniform2f(this.dispUniforms.u_resolution, ctx.width, ctx.height);
+    gl.uniform1f(this.dispUniforms.u_time, ctx.time);
+    gl.uniform1f(this.dispUniforms.u_strokeWidth, this.strokeWidth);
+    gl.uniform1f(this.dispUniforms.u_breakFreq, this.breakFreq);
+
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+  }
+
+  onGesture(_ctx: EngineContext, event: GestureEvent) {
+    const uv: [number, number] = [event.pos.x, 1.0 - event.pos.y];
+    if (event.type === 'tap') {
+      this.pendingImpulse = uv;
+    } else if (event.type === 'drag-start') {
+      this.dragging = true;
+      this.dragPos = uv;
+      this.pendingImpulse = uv;
+    } else if (event.type === 'drag-move') {
+      this.dragPos = uv;
+    } else if (event.type === 'drag-end') {
+      this.dragging = false;
+    }
+  }
+
+  destroy(ctx: EngineContext) {
+    const { gl } = ctx;
+    gl.deleteProgram(this.simProgram);
+    gl.deleteProgram(this.displayProgram);
+    gl.deleteVertexArray(this.vao);
+    this.fbo.destroy(gl);
+    this.sliders.destroy();
+  }
+
+  private getUniforms(
+    gl: WebGL2RenderingContext,
+    program: WebGLProgram,
+    names: string[],
+  ): Record<string, WebGLUniformLocation | null> {
+    const out: Record<string, WebGLUniformLocation | null> = {};
+    for (const name of names) {
+      out[name] = gl.getUniformLocation(program, name);
+    }
+    return out;
+  }
+}

--- a/src/plugins/ripple-drop/simulate.glsl
+++ b/src/plugins/ripple-drop/simulate.glsl
@@ -1,0 +1,44 @@
+#version 300 es
+precision highp float;
+
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform sampler2D u_prevState;   // previous heightfield (ping-pong read)
+uniform vec2 u_resolution;
+uniform float u_damping;         // wave damping factor
+uniform float u_waveSpeed;       // wave propagation speed
+uniform vec2 u_impulsePos;       // normalized click position (-1 if none)
+uniform float u_impulseStrength; // impulse magnitude
+
+void main() {
+  vec2 texel = 1.0 / u_resolution;
+
+  // Current and neighbor heights from previous state
+  // .r = current height, .g = previous height
+  vec4 state = texture(u_prevState, v_uv);
+  float h = state.r;
+  float hPrev = state.g;
+
+  // Laplacian (4-neighbor stencil)
+  float hL = texture(u_prevState, v_uv + vec2(-texel.x, 0.0)).r;
+  float hR = texture(u_prevState, v_uv + vec2( texel.x, 0.0)).r;
+  float hU = texture(u_prevState, v_uv + vec2(0.0,  texel.y)).r;
+  float hD = texture(u_prevState, v_uv + vec2(0.0, -texel.y)).r;
+  float laplacian = (hL + hR + hU + hD) - 4.0 * h;
+
+  // Wave equation: h_next = 2h - h_prev + c^2 * laplacian - damping
+  float c2 = u_waveSpeed * u_waveSpeed;
+  float hNext = 2.0 * h - hPrev + c2 * laplacian;
+  hNext *= u_damping;
+
+  // Apply impulse if click happened
+  if (u_impulsePos.x >= 0.0) {
+    float dist = length(v_uv - u_impulsePos);
+    float impulse = u_impulseStrength * exp(-dist * dist * 800.0);
+    hNext += impulse;
+  }
+
+  // Store: .r = new height, .g = old height (for next frame's velocity term)
+  fragColor = vec4(hNext, h, 0.0, 1.0);
+}

--- a/src/shaders/lib/anime-style.glsl
+++ b/src/shaders/lib/anime-style.glsl
@@ -1,0 +1,32 @@
+// ── Anime-Style Shader Utilities ────────────────────────────────────
+
+// Renders SDF distance as a hand-drawn ink stroke with thickness variation
+// and intentional breaks via noise
+float inkStroke(float d, float width, float breakFreq, float seed) {
+  // Noise-driven width variation
+  float noiseVal = snoise(vec2(seed * 7.3, seed * 3.7));
+  float w = width * (0.7 + 0.3 * noiseVal);
+
+  // Break pattern: creates gaps in the stroke
+  float breakNoise = snoise(vec2(seed * 13.1, seed * 5.9));
+  float breakMask = smoothstep(-0.2, 0.3, sin(seed * breakFreq + breakNoise * 2.0));
+
+  // Stroke alpha from SDF
+  float inner = smoothstep(w, w * 0.3, abs(d));
+  return inner * breakMask;
+}
+
+// Anime-style soft glow falloff
+float softGlow(float d, float intensity, float falloff) {
+  return intensity / (1.0 + pow(max(d, 0.0) * falloff, 2.0));
+}
+
+// Exponential glow for bloom passes
+float expGlow(float d, float intensity, float falloff) {
+  return intensity * exp(-abs(d) * falloff);
+}
+
+// Color quantization for cel-shading / posterization
+vec3 posterize(vec3 color, float levels) {
+  return floor(color * levels + 0.5) / levels;
+}

--- a/src/shaders/lib/noise.glsl
+++ b/src/shaders/lib/noise.glsl
@@ -1,0 +1,75 @@
+// ── 2D Simplex Noise ────────────────────────────────────────────────
+// Based on Ashima Arts / Ian McEwan implementation (MIT)
+
+vec3 mod289(vec3 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+vec2 mod289(vec2 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+vec3 permute(vec3 x) { return mod289(((x * 34.0) + 10.0) * x); }
+
+float snoise(vec2 v) {
+  const vec4 C = vec4(
+    0.211324865405187,   // (3.0 - sqrt(3.0)) / 6.0
+    0.366025403784439,   // 0.5 * (sqrt(3.0) - 1.0)
+   -0.577350269189626,   // -1.0 + 2.0 * C.x
+    0.024390243902439    // 1.0 / 41.0
+  );
+  vec2 i = floor(v + dot(v, C.yy));
+  vec2 x0 = v - i + dot(i, C.xx);
+
+  vec2 i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+  vec4 x12 = x0.xyxy + C.xxzz;
+  x12.xy -= i1;
+
+  i = mod289(i);
+  vec3 p = permute(permute(i.y + vec3(0.0, i1.y, 1.0)) + i.x + vec3(0.0, i1.x, 1.0));
+
+  vec3 m = max(0.5 - vec3(dot(x0, x0), dot(x12.xy, x12.xy), dot(x12.zw, x12.zw)), 0.0);
+  m = m * m;
+  m = m * m;
+
+  vec3 x_ = 2.0 * fract(p * C.www) - 1.0;
+  vec3 h = abs(x_) - 0.5;
+  vec3 ox = floor(x_ + 0.5);
+  vec3 a0 = x_ - ox;
+
+  m *= 1.79284291400159 - 0.85373472095314 * (a0 * a0 + h * h);
+
+  vec3 g;
+  g.x = a0.x * x0.x + h.x * x0.y;
+  g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+
+  return 130.0 * dot(m, g);
+}
+
+// ── Fractional Brownian Motion ──────────────────────────────────────
+
+float fbm(vec2 p, int octaves, float lacunarity, float gain) {
+  float sum = 0.0;
+  float amp = 1.0;
+  float freq = 1.0;
+  float total = 0.0;
+  for (int i = 0; i < 8; i++) {
+    if (i >= octaves) break;
+    sum += amp * snoise(p * freq);
+    total += amp;
+    freq *= lacunarity;
+    amp *= gain;
+  }
+  return sum / total;
+}
+
+float fbm3(vec2 p) { return fbm(p, 3, 2.0, 0.5); }
+float fbm5(vec2 p) { return fbm(p, 5, 2.0, 0.5); }
+
+// ── Hash Functions ──────────────────────────────────────────────────
+
+float hash21(vec2 p) {
+  p = fract(p * vec2(123.34, 456.21));
+  p += dot(p, p + 45.32);
+  return fract(p.x * p.y);
+}
+
+vec2 hash22(vec2 p) {
+  vec3 a = fract(p.xyx * vec3(123.34, 234.34, 345.65));
+  a += dot(a, a + 34.45);
+  return fract(vec2(a.x * a.y, a.y * a.z));
+}

--- a/src/shaders/lib/sdf2d.glsl
+++ b/src/shaders/lib/sdf2d.glsl
@@ -1,0 +1,32 @@
+// ── 2D SDF Primitives ───────────────────────────────────────────────
+
+float sdCircle(vec2 p, float r) {
+  return length(p) - r;
+}
+
+float sdLine(vec2 p, vec2 a, vec2 b) {
+  vec2 pa = p - a, ba = b - a;
+  float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+  return length(pa - ba * h);
+}
+
+float sdArc(vec2 p, float r, float aperture) {
+  float ha = aperture * 0.5;
+  vec2 sca = vec2(sin(ha), cos(ha));
+  p.x = abs(p.x);
+  float l = length(p) - r;
+  float m = length(p - sca * clamp(dot(p, sca), 0.0, r));
+  return max(l, m * sign(sca.y * p.x - sca.x * p.y));
+}
+
+// ── Smooth Boolean Operations ───────────────────────────────────────
+
+float opSmoothUnion(float d1, float d2, float k) {
+  float h = clamp(0.5 + 0.5 * (d2 - d1) / k, 0.0, 1.0);
+  return mix(d2, d1, h) - k * h * (1.0 - h);
+}
+
+float opSmoothSubtraction(float d1, float d2, float k) {
+  float h = clamp(0.5 - 0.5 * (d2 + d1) / k, 0.0, 1.0);
+  return mix(d2, -d1, h) + k * h * (1.0 - h);
+}


### PR DESCRIPTION
Implement three WebGL2 shader demos inspired by the 1986 anime film Windaria:
- Ripple Drop: 2D wave equation simulation with hand-drawn ink stroke rendering
- Laser Bird: SDF bird shape with multi-pass Gaussian bloom and starfield
- Boat Wake: Kelvin wake foam simulation with ukiyo-e-style bold outlines

Includes shared shader utilities (noise, SDF, anime-style helpers), a minimal
parameter slider UI, and a comprehensive reference document on 80s anime
production techniques mapped to shader implementations.

https://claude.ai/code/session_01YS1pzCh6RFcqweVYdr8urV