### PR TITLE
Fix GitHub Pages black screen by correcting base path case

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vite';
 import glsl from 'vite-plugin-glsl';
 
 export default defineConfig({
-  base: '/gl-demo-garden/',
+  base: '/GL-Demo-Garden/',
   plugins: [glsl()],
 });


### PR DESCRIPTION
The Vite base was set to '/gl-demo-garden/' (lowercase) but the repo
name is 'GL-Demo-Garden' (mixed case). GitHub Pages serves at
/GL-Demo-Garden/, so all asset URLs were 404ing, leaving only the
black background visible.

https://claude.ai/code/session_01JjruefdFGWbihkPoZsiiWH