### PR TITLE
Use relative base path and add visible error handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,13 @@
   </style>
 </head>
 <body>
+  <p id="gl-error" style="color:#fff;font-family:system-ui,sans-serif;padding:2rem;display:none;"></p>
+  <script>
+    window.addEventListener('error', function(e) {
+      var el = document.getElementById('gl-error');
+      if (el) { el.textContent = 'Error: ' + e.message; el.style.display = 'block'; }
+    });
+  </script>
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vite';
 import glsl from 'vite-plugin-glsl';
 
 export default defineConfig({
-  base: '/GL-Demo-Garden/',
+  base: './',
   plugins: [glsl()],
 });


### PR DESCRIPTION
Switch Vite base from absolute '/GL-Demo-Garden/' to relative './' so asset URLs work regardless of the deployment path. Also add an inline error handler to surface JS errors visibly instead of showing a silent black screen.

https://claude.ai/code/session_01JjruefdFGWbihkPoZsiiWH