### PR TITLE
Fix ripple drop stability, Turing pattern legibility, and wobbly cells touch

### DIFF
--- a/src/plugin/FragmentShaderPlugin.ts
+++ b/src/plugin/FragmentShaderPlugin.ts
@@ -41,7 +41,7 @@ export abstract class FragmentShaderPlugin implements Plugin {
   }
 
   onGesture(_ctx: EngineContext, event: GestureEvent) {
-    this.mousePos = [event.pos.x, event.pos.y];
+    this.mousePos = [event.pos.x, 1.0 - event.pos.y];
   }
 
   destroy(ctx: EngineContext) {

--- a/src/plugins/ripple-drop/simulate.glsl
+++ b/src/plugins/ripple-drop/simulate.glsl
@@ -32,6 +32,11 @@ void main() {
   float hNext = 2.0 * h - hPrev + c2 * laplacian;
   hNext *= u_damping;
 
+  // Clamp to prevent numerical blowup at high wave speeds
+  hNext = clamp(hNext, -1.0, 1.0);
+  // Snap near-zero values to zero so water fully resets
+  hNext *= step(0.0001, abs(hNext));
+
   // Apply impulse if click happened
   if (u_impulsePos.x >= 0.0) {
     float dist = length(v_uv - u_impulsePos);

--- a/src/plugins/turing-patterns/compute.glsl
+++ b/src/plugins/turing-patterns/compute.glsl
@@ -28,8 +28,8 @@ void main() {
   float lapB = (L.g + R.g + U.g + D.g) - 4.0 * B;
 
   // Gray-Scott reaction-diffusion
-  float dA = 1.0;   // Diffusion rate for A
-  float dB = 0.5;   // Diffusion rate for B
+  float dA = 0.5;   // Diffusion rate for A
+  float dB = 0.25;  // Diffusion rate for B
   float reaction = A * B * B;
 
   float newA = A + (dA * lapA - reaction + u_feed * (1.0 - A)) * u_dt;

--- a/src/plugins/turing-patterns/index.ts
+++ b/src/plugins/turing-patterns/index.ts
@@ -86,7 +86,7 @@ export class TuringPatternsPlugin implements Plugin {
 
   render(ctx: EngineContext) {
     const { gl } = ctx;
-    const stepsPerFrame = 12;
+    const stepsPerFrame = 8;
 
     gl.bindVertexArray(this.vao);
 


### PR DESCRIPTION
- Ripple drop: clamp heights to [-1,1] to prevent numerical blowup at high
  wave speeds, and snap near-zero values to zero so water fully resets
- Turing patterns: halve diffusion rates (dA=0.5, dB=0.25) and reduce steps
  per frame (12→8) for larger, more legible pattern features
- Wobbly cells: flip mouse Y in FragmentShaderPlugin to match OpenGL's
  bottom-up UV convention, fixing inverted vertical touch response

https://claude.ai/code/session_017gWaVQLyrWvU8kVDqGw9vj