### PR TITLE
Tune Turing patterns demo to produce pufferfish-like labyrinthine patterns

### DIFF
--- a/src/plugins/turing-patterns/compute.glsl
+++ b/src/plugins/turing-patterns/compute.glsl
@@ -18,18 +18,23 @@ void main() {
   float A = state.r;
   float B = state.g;
 
-  // 5-point Laplacian stencil
-  vec4 L = texture(u_state, v_uv + vec2(-u_texelSize.x, 0.0));
-  vec4 R = texture(u_state, v_uv + vec2( u_texelSize.x, 0.0));
-  vec4 U = texture(u_state, v_uv + vec2(0.0,  u_texelSize.y));
-  vec4 D = texture(u_state, v_uv + vec2(0.0, -u_texelSize.y));
+  // 9-point Laplacian stencil (weighted, more isotropic)
+  vec2 tx = u_texelSize;
+  vec4 L  = texture(u_state, v_uv + vec2(-tx.x,  0.0));
+  vec4 R  = texture(u_state, v_uv + vec2( tx.x,  0.0));
+  vec4 U  = texture(u_state, v_uv + vec2( 0.0,   tx.y));
+  vec4 D  = texture(u_state, v_uv + vec2( 0.0,  -tx.y));
+  vec4 LU = texture(u_state, v_uv + vec2(-tx.x,  tx.y));
+  vec4 RU = texture(u_state, v_uv + vec2( tx.x,  tx.y));
+  vec4 LD = texture(u_state, v_uv + vec2(-tx.x, -tx.y));
+  vec4 RD = texture(u_state, v_uv + vec2( tx.x, -tx.y));
 
-  float lapA = (L.r + R.r + U.r + D.r) - 4.0 * A;
-  float lapB = (L.g + R.g + U.g + D.g) - 4.0 * B;
+  float lapA = 0.2 * (L.r + R.r + U.r + D.r) + 0.05 * (LU.r + RU.r + LD.r + RD.r) - 1.0 * A;
+  float lapB = 0.2 * (L.g + R.g + U.g + D.g) + 0.05 * (LU.g + RU.g + LD.g + RD.g) - 1.0 * B;
 
   // Gray-Scott reaction-diffusion
-  float dA = 0.5;   // Diffusion rate for A
-  float dB = 0.25;  // Diffusion rate for B
+  float dA = 1.0;    // Diffusion rate for A
+  float dB = 0.5;    // Diffusion rate for B
   float reaction = A * B * B;
 
   float newA = A + (dA * lapA - reaction + u_feed * (1.0 - A)) * u_dt;

--- a/src/plugins/turing-patterns/display.glsl
+++ b/src/plugins/turing-patterns/display.glsl
@@ -11,21 +11,14 @@ void main() {
   float A = state.r;
   float B = state.g;
 
-  // Colormap: map concentrations to a nice palette
-  float v = A - B;
-  vec3 c1 = vec3(0.01, 0.02, 0.08); // deep blue-black
-  vec3 c2 = vec3(0.1, 0.3, 0.6);    // ocean blue
-  vec3 c3 = vec3(0.4, 0.8, 0.7);    // teal
-  vec3 c4 = vec3(0.95, 0.9, 0.8);   // warm white
+  // Map B concentration to pufferfish coloring:
+  // Low B → golden yellow (background), High B → dark blue-black (maze lines)
+  float t = smoothstep(0.05, 0.35, B);
 
-  vec3 color;
-  if (v < 0.33) {
-    color = mix(c1, c2, v / 0.33);
-  } else if (v < 0.66) {
-    color = mix(c2, c3, (v - 0.33) / 0.33);
-  } else {
-    color = mix(c3, c4, (v - 0.66) / 0.34);
-  }
+  vec3 gold   = vec3(0.85, 0.72, 0.20);  // golden yellow background
+  vec3 dark   = vec3(0.05, 0.06, 0.12);  // dark blue-black lines
+
+  vec3 color = mix(gold, dark, t);
 
   fragColor = vec4(color, 1.0);
 }

--- a/src/plugins/turing-patterns/index.ts
+++ b/src/plugins/turing-patterns/index.ts
@@ -16,9 +16,9 @@ export class TuringPatternsPlugin implements Plugin {
   private mousePos: [number, number] = [0.5, 0.5];
   private mouseDown = 0;
 
-  // Gray-Scott parameters — "coral growth" preset
-  private feed = 0.0545;
-  private kill = 0.062;
+  // Gray-Scott parameters — "labyrinthine" preset (pufferfish-like maze pattern)
+  private feed = 0.037;
+  private kill = 0.06;
 
   init(ctx: EngineContext) {
     const { gl } = ctx;
@@ -57,12 +57,12 @@ export class TuringPatternsPlugin implements Plugin {
       void main() {
         float A = 1.0;
         float B = 0.0;
-        // Random scattered seeds
-        vec2 cell = floor(v_uv * 20.0);
+        // Dense random scattered seeds for labyrinthine pattern coverage
+        vec2 cell = floor(v_uv * 30.0);
         float r = hash(cell);
-        if (r > 0.85) {
-          float d = length(fract(v_uv * 20.0) - 0.5);
-          B = smoothstep(0.4, 0.1, d);
+        if (r > 0.65) {
+          float d = length(fract(v_uv * 30.0) - 0.5);
+          B = smoothstep(0.4, 0.05, d);
         }
         fragColor = vec4(A, B, 0.0, 1.0);
       }
@@ -86,7 +86,7 @@ export class TuringPatternsPlugin implements Plugin {
 
   render(ctx: EngineContext) {
     const { gl } = ctx;
-    const stepsPerFrame = 8;
+    const stepsPerFrame = 12;
 
     gl.bindVertexArray(this.vao);
 


### PR DESCRIPTION
- Change Gray-Scott parameters from coral-growth (f=0.0545, k=0.062) to
  labyrinthine regime (f=0.037, k=0.06) for maze-like patterns
- Upgrade to 9-point weighted Laplacian for smoother, more isotropic diffusion
- Update colormap to golden yellow background with dark blue-black maze lines
  matching pufferfish skin coloring
- Increase initial seed density for better pattern coverage
- Bump simulation steps per frame from 8 to 12 for faster convergence

https://claude.ai/code/session_01X7oGXYuRyqkwsJAKcyXcGj