### PR TITLE
Add zoomed follow-cam and anime stylization to boat wake demo

### DIFF
--- a/src/plugins/boat-wake/display.glsl
+++ b/src/plugins/boat-wake/display.glsl
@@ -12,74 +12,200 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform float u_strokeBoldness;
 uniform vec2 u_boatPos;
+uniform vec2 u_boatDir;
+uniform float u_zoom;
+uniform float u_aspect;
+uniform float u_whorlIntensity;
+uniform float u_boatSpeed;
 
 // ── Constants ───────────────────────────────────────────────────────
-const vec3 WATER_COLOR   = vec3(0.102, 0.290, 0.353);  // #1a4a5a
-const vec3 WATER_DEEP    = vec3(0.051, 0.157, 0.251);  // #0d2840
-const vec3 FOAM_COLOR    = vec3(0.910, 0.941, 1.0);    // #e8f0ff
-const vec3 OUTLINE_COLOR = vec3(0.102, 0.165, 0.227);  // #1a2a3a
-const float CURL_SCALE   = 12.0;
+const vec3 WATER_COLOR   = vec3(0.05, 0.30, 0.55);   // Rich blue
+const vec3 WATER_DEEP    = vec3(0.02, 0.10, 0.30);    // Deep navy
+const vec3 FOAM_COLOR    = vec3(1.0, 1.0, 1.0);       // Pure white crests
+const vec3 FOAM_MID      = vec3(0.6, 0.85, 0.95);     // Light cyan mid-foam
+const vec3 OUTLINE_COLOR = vec3(0.05, 0.08, 0.15);    // Near-black ink
+const vec2 BOAT_SCREEN_POS = vec2(0.5, 0.85);
+const float WAKE_HALF_ANGLE = 0.45;  // Wider for visual drama
 
 void main() {
-  vec2 texel = 1.0 / u_resolution;
-  float aspect = u_resolution.x / u_resolution.y;
+  // ── Camera transform: screen UV → sim UV ──
+  vec2 offset = v_uv - BOAT_SCREEN_POS;
+  offset.x *= u_aspect;
+  offset /= u_zoom;
 
-  // Sample foam field
-  float foam = texture(u_foam, v_uv).r;
+  // Rotate so boatDir always points up on screen
+  float cosA = u_boatDir.y;
+  float sinA = u_boatDir.x;
+  vec2 rotated = vec2(
+    cosA * offset.x - sinA * offset.y,
+    sinA * offset.x + cosA * offset.y
+  );
+  vec2 simUV = u_boatPos + rotated;
 
-  // Gradient of foam for edge detection
-  float fL = texture(u_foam, v_uv + vec2(-texel.x, 0.0)).r;
-  float fR = texture(u_foam, v_uv + vec2( texel.x, 0.0)).r;
-  float fU = texture(u_foam, v_uv + vec2(0.0,  texel.y)).r;
-  float fD = texture(u_foam, v_uv + vec2(0.0, -texel.y)).r;
+  // ── Sample foam field ──
+  bool inBounds = all(greaterThanEqual(simUV, vec2(0.0))) && all(lessThanEqual(simUV, vec2(1.0)));
+  float foam = inBounds ? texture(u_foam, simUV).r : 0.0;
+
+  // Gradient for edge detection (in sim-space texel units)
+  ivec2 simRes = textureSize(u_foam, 0);
+  vec2 simTexel = 1.0 / vec2(simRes);
+  float fL = inBounds ? texture(u_foam, simUV + vec2(-simTexel.x, 0.0)).r : 0.0;
+  float fR = inBounds ? texture(u_foam, simUV + vec2( simTexel.x, 0.0)).r : 0.0;
+  float fU = inBounds ? texture(u_foam, simUV + vec2(0.0,  simTexel.y)).r : 0.0;
+  float fD = inBounds ? texture(u_foam, simUV + vec2(0.0, -simTexel.y)).r : 0.0;
   vec2 grad = vec2(fR - fL, fU - fD) * 0.5;
   float gradMag = length(grad);
 
-  // ── Water base ──
-  // Subtle wave pattern
-  float waveNoise = snoise(v_uv * 6.0 + vec2(u_time * 0.08, u_time * 0.03)) * 0.5 + 0.5;
-  float waveNoise2 = snoise(v_uv * 15.0 + vec2(-u_time * 0.05, u_time * 0.06)) * 0.5 + 0.5;
+  // ── Water base (screen-space noise for stable background) ──
+  float waveNoise = snoise(v_uv * 8.0 + vec2(u_time * 0.06, u_time * 0.02)) * 0.5 + 0.5;
+  float waveNoise2 = snoise(v_uv * 18.0 + vec2(-u_time * 0.04, u_time * 0.05)) * 0.5 + 0.5;
   vec3 water = mix(WATER_DEEP, WATER_COLOR, waveNoise * 0.6 + 0.2);
-  water += vec3(0.01, 0.02, 0.03) * waveNoise2;
+  water += vec3(0.01, 0.02, 0.04) * waveNoise2;
+
+  // ── Posterized foam bands (cel-shaded) ──
+  float foamBand = floor(foam * 4.0 + 0.5) / 4.0;
 
   // ── Foam rendering ──
-  // Bold outlines at foam edges (ukiyo-e style)
-  float edgeSeed = atan(grad.y, grad.x) * 5.0 + length(v_uv - u_boatPos) * 30.0;
+  // Bold ink outlines at foam edges
+  float edgeSeed = atan(grad.y, grad.x) * 5.0 + length(v_uv - BOAT_SCREEN_POS) * 30.0;
   float edgeStroke = inkStroke(
-    gradMag - 0.02,
-    u_strokeBoldness * 0.02,
-    5.0,
+    gradMag - 0.015,
+    u_strokeBoldness * 0.035,   // Thicker strokes
+    3.0,                         // Fewer breaks for bolder lines
     edgeSeed
   );
-  edgeStroke *= smoothstep(0.005, 0.02, gradMag);
+  edgeStroke *= smoothstep(0.003, 0.015, gradMag);
 
-  // Interior foam fill (lighter, flat regions)
-  float foamFill = smoothstep(0.15, 0.4, foam);
+  // Interior foam fill with cel bands
+  float foamFill = smoothstep(0.1, 0.3, foamBand);
 
-  // Curling wave shapes from warped noise
-  vec2 warpedUV = v_uv * CURL_SCALE + vec2(
-    snoise(v_uv * 4.0 + u_time * 0.1) * 0.5,
-    snoise(v_uv * 4.0 + 100.0 + u_time * 0.1) * 0.5
+  // ── Spiral whorls at foam edges ──
+  vec2 toPixelSim = simUV - u_boatPos;
+  float distFromBoat = length(toPixelSim);
+  float angleFromBoat = atan(toPixelSim.y, toPixelSim.x);
+
+  // Spiral distortion
+  float spiralWarp = angleFromBoat * 2.0 + distFromBoat * 25.0 - u_time * 2.0;
+  float whorl = sin(spiralWarp) * 0.5 + 0.5;
+  // Mask to foam edges only
+  float whorlMask = smoothstep(0.05, 0.15, foam) * smoothstep(0.45, 0.2, foam);
+  whorl *= whorlMask * u_whorlIntensity;
+
+  // Secondary smaller whorls
+  float spiralWarp2 = angleFromBoat * 4.0 - distFromBoat * 40.0 + u_time * 3.0;
+  float whorl2 = sin(spiralWarp2) * 0.5 + 0.5;
+  whorl2 *= whorlMask * u_whorlIntensity * 0.5;
+
+  // ── Curling wave shapes (warped noise, sim-space) ──
+  vec2 warpedUV = simUV * 14.0 + vec2(
+    snoise(simUV * 5.0 + u_time * 0.08) * 0.6,
+    snoise(simUV * 5.0 + 100.0 + u_time * 0.08) * 0.6
   );
-  float curlPattern = smoothstep(0.3, 0.5, snoise(warpedUV)) * foam;
+  float curlPattern = smoothstep(0.25, 0.5, snoise(warpedUV)) * foam;
 
-  // Composite foam
-  vec3 foamRender = mix(water, FOAM_COLOR * 0.8, foamFill * 0.6);
-  foamRender = mix(foamRender, FOAM_COLOR, curlPattern * 0.4);
+  // ── Outer ripple arc lines ──
+  // V-shaped arcs behind the boat, following wake angle
+  float behindBoat = -dot(toPixelSim, u_boatDir);
+  vec2 boatPerp = vec2(-u_boatDir.y, u_boatDir.x);
+  float perpDist = dot(toPixelSim, boatPerp);
 
-  // Bold outline
-  foamRender = mix(foamRender, OUTLINE_COLOR, edgeStroke * 0.7);
+  // Concentric V-arcs: distance along the wake envelope
+  float arcDist = behindBoat + abs(perpDist) * 0.6;
+  float ripplePhase = arcDist * 50.0 - u_time * 2.5;
+  float ripple = sin(ripplePhase);
+
+  // Only show ripples outside main foam, behind the boat
+  float rippleMask = step(0.01, behindBoat)
+    * smoothstep(0.0, 0.03, foam)
+    * smoothstep(0.2, 0.08, foam);
+
+  // Also add faint ripples beyond the wake edges
+  float wakeWidth = behindBoat * tan(WAKE_HALF_ANGLE);
+  float outerRippleMask = step(0.02, behindBoat)
+    * smoothstep(wakeWidth * 0.9, wakeWidth * 1.3, abs(perpDist))
+    * smoothstep(wakeWidth * 2.5, wakeWidth * 1.3, abs(perpDist))
+    * exp(-behindBoat * 2.5);
+
+  float rippleStroke = inkStroke(
+    ripple,
+    0.018 * u_strokeBoldness,
+    3.5,
+    ripplePhase * 1.5
+  );
+  rippleStroke *= max(rippleMask, outerRippleMask * 0.7);
+
+  // ── Speed lines (screen-space radial streaks) ──
+  vec2 fromBoat = v_uv - BOAT_SCREEN_POS;
+  fromBoat.x *= u_aspect;
+  float screenDist = length(fromBoat);
+  float screenAngle = atan(fromBoat.x, -fromBoat.y);
+
+  float lineCount = 50.0;
+  float linePhase = screenAngle * lineCount;
+  float speedLine = smoothstep(0.35, 0.5, sin(linePhase));
+
+  // Fade: near boat, only behind, scale with speed
+  speedLine *= smoothstep(0.02, 0.06, screenDist) * smoothstep(0.35, 0.1, screenDist);
+  speedLine *= smoothstep(0.0, -0.02, fromBoat.y);  // Only below boat (behind)
+  speedLine *= 0.12 * u_boatSpeed;
+
+  // ── Composite ──
+  // Base foam color with cel bands
+  vec3 foamRender = mix(water, FOAM_MID, foamFill * 0.5);
+  foamRender = mix(foamRender, FOAM_COLOR * 0.9, smoothstep(0.5, 0.75, foamBand) * 0.7);
+
+  // Curl patterns
+  foamRender = mix(foamRender, FOAM_COLOR, curlPattern * 0.35);
+
+  // Whorls
+  foamRender = mix(foamRender, FOAM_COLOR * 0.95, whorl * 0.4);
+  foamRender = mix(foamRender, FOAM_MID, whorl2 * 0.3);
 
   // Bright foam highlights
-  float highlight = smoothstep(0.5, 0.8, foam) * 0.3;
+  float highlight = smoothstep(0.6, 0.9, foam) * 0.35;
   foamRender += vec3(highlight);
 
-  // ── Boat marker ──
-  float boatDist = length((v_uv - u_boatPos) * vec2(aspect, 1.0));
-  float boatMarker = smoothstep(0.008, 0.004, boatDist);
-  vec3 boatColor = vec3(0.9, 0.85, 0.7);
+  // Bold ink outlines
+  foamRender = mix(foamRender, OUTLINE_COLOR, edgeStroke * 0.8);
 
-  vec3 color = mix(foamRender, boatColor, boatMarker);
+  // Ripple arc lines
+  foamRender = mix(foamRender, OUTLINE_COLOR, rippleStroke * 0.6);
+
+  // Speed lines (subtle white streaks)
+  foamRender += vec3(speedLine);
+
+  // ── Boat hull (screen-space, stern poking in from top) ──
+  vec2 hullOffset = v_uv - BOAT_SCREEN_POS;
+  hullOffset.x *= u_aspect;
+
+  // Wedge-shaped hull: wider at stern (y=0), narrows upward
+  float hullExtent = 0.04;  // How far stern extends down into view
+  float hullWidth = 0.025;  // Half-width at the stern
+  float hullTaper = 0.6;    // How quickly it narrows going up
+
+  // SDF: pointed hull shape
+  float yNorm = -hullOffset.y / hullExtent;  // 0 at boat pos, 1 at stern bottom
+  float localWidth = hullWidth * (1.0 - yNorm * hullTaper);
+  localWidth = max(localWidth, 0.002);
+
+  float inHull = step(0.0, -hullOffset.y) * step(yNorm, 1.0)
+               * step(abs(hullOffset.x), localWidth);
+
+  // Hull outline
+  float hullDist = abs(hullOffset.x) - localWidth;
+  float hullOutline = smoothstep(0.004, 0.001, abs(hullDist)) * step(0.0, -hullOffset.y) * step(yNorm, 1.0);
+  // Stern curve
+  float sternDist = length(vec2(hullOffset.x, hullOffset.y + hullExtent)) - hullWidth;
+  float sternLine = smoothstep(0.004, 0.001, abs(sternDist)) * step(0.0, hullOffset.y + hullExtent);
+
+  vec3 hullColor = vec3(0.35, 0.25, 0.18);    // Dark wood
+  vec3 hullHighlight = vec3(0.55, 0.42, 0.30); // Lighter wood
+
+  vec3 color = foamRender;
+  // Fill hull
+  color = mix(color, mix(hullColor, hullHighlight, yNorm * 0.5), inHull * 0.95);
+  // Hull outline strokes
+  color = mix(color, OUTLINE_COLOR, max(hullOutline, sternLine) * 0.9);
 
   fragColor = vec4(color, 1.0);
 }

--- a/src/plugins/boat-wake/index.ts
+++ b/src/plugins/boat-wake/index.ts
@@ -28,6 +28,8 @@ export class BoatWakePlugin implements Plugin {
   private foamDecay = 0.985;
   private curlIntensity = 1.0;
   private strokeBoldness = 1.0;
+  private cameraZoom = 3.5;
+  private whorlIntensity = 1.0;
 
   // Boat state
   private boatPos: [number, number] = [0.5, 0.5];
@@ -56,6 +58,7 @@ export class BoatWakePlugin implements Plugin {
     ]);
     this.dispU = this.getUniforms(gl, this.displayProgram, [
       'u_foam', 'u_resolution', 'u_time', 'u_strokeBoldness', 'u_boatPos',
+      'u_boatDir', 'u_zoom', 'u_aspect', 'u_whorlIntensity', 'u_boatSpeed',
     ]);
 
     this.sliders = new ParamSlider();
@@ -74,6 +77,14 @@ export class BoatWakePlugin implements Plugin {
     this.sliders.addSlider({
       label: 'Stroke Bold', min: 0.2, max: 3.0, value: this.strokeBoldness,
       onChange: (v) => { this.strokeBoldness = v; },
+    });
+    this.sliders.addSlider({
+      label: 'Camera Zoom', min: 2.0, max: 6.0, value: this.cameraZoom,
+      onChange: (v) => { this.cameraZoom = v; },
+    });
+    this.sliders.addSlider({
+      label: 'Whorl Intensity', min: 0.0, max: 2.0, value: this.whorlIntensity,
+      onChange: (v) => { this.whorlIntensity = v; },
     });
   }
 
@@ -107,26 +118,54 @@ export class BoatWakePlugin implements Plugin {
 
     gl.useProgram(this.displayProgram);
     this.fbo.bindRead(gl, 0);
+    // Smooth sampling and clamp for zoomed display
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
     gl.uniform1i(this.dispU.u_foam, 0);
     gl.uniform2f(this.dispU.u_resolution, ctx.width, ctx.height);
     gl.uniform1f(this.dispU.u_time, ctx.time);
     gl.uniform1f(this.dispU.u_strokeBoldness, this.strokeBoldness);
     gl.uniform2f(this.dispU.u_boatPos, this.boatPos[0], this.boatPos[1]);
+    gl.uniform2f(this.dispU.u_boatDir, this.boatDir[0], this.boatDir[1]);
+    gl.uniform1f(this.dispU.u_zoom, this.cameraZoom);
+    gl.uniform1f(this.dispU.u_aspect, ctx.width / ctx.height);
+    gl.uniform1f(this.dispU.u_whorlIntensity, this.whorlIntensity);
+    gl.uniform1f(this.dispU.u_boatSpeed, this.boatSpeed);
 
     gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+    // Restore texture params for next sim pass
+    this.fbo.bindRead(gl, 0);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
   }
 
-  onGesture(_ctx: EngineContext, event: GestureEvent) {
+  onGesture(ctx: EngineContext, event: GestureEvent) {
+    const screenToSim = (sx: number, sy: number): [number, number] => {
+      const aspect = ctx.width / ctx.height;
+      let dx = (sx - 0.5) * aspect / this.cameraZoom;
+      let dy = (sy - 0.85) / this.cameraZoom;
+      // Rotate by +boatAngle (inverse of display rotation)
+      const cosA = this.boatDir[1];
+      const sinA = this.boatDir[0];
+      return [
+        this.boatPos[0] + cosA * dx - sinA * dy,
+        this.boatPos[1] + sinA * dx + cosA * dy,
+      ];
+    };
+
     if (event.type === 'drag-start' || event.type === 'drag-move') {
       this.userControlled = true;
-      this.targetPos = [event.pos.x, 1.0 - event.pos.y];
+      this.targetPos = screenToSim(event.pos.x, 1.0 - event.pos.y);
     } else if (event.type === 'drag-end') {
       this.userControlled = false;
       this.targetPos = null;
     } else if (event.type === 'tap') {
-      this.targetPos = [event.pos.x, 1.0 - event.pos.y];
+      this.targetPos = screenToSim(event.pos.x, 1.0 - event.pos.y);
       this.userControlled = true;
-      // Release after reaching target
       setTimeout(() => { this.userControlled = false; this.targetPos = null; }, 2000);
     }
   }

--- a/src/plugins/boat-wake/wake-sim.glsl
+++ b/src/plugins/boat-wake/wake-sim.glsl
@@ -16,8 +16,8 @@ uniform float u_curlIntensity;
 uniform float u_time;
 
 // ── Constants ───────────────────────────────────────────────────────
-const float WAKE_HALF_ANGLE = 0.34;  // ~19.5 degrees in radians
-const float FOAM_EMIT_RADIUS = 0.03;
+const float WAKE_HALF_ANGLE = 0.48;  // ~27.5 degrees, wider for anime drama
+const float FOAM_EMIT_RADIUS = 0.05; // Larger hull foam for zoomed view
 const float DIFFUSION = 0.3;
 const float ADVECTION = 0.5;
 


### PR DESCRIPTION
Camera now locks to the boat with the stern poking into the top of
frame and the wake filling the screen below. Adds spiral whorls,
V-shaped ripple arcs, speed lines, posterized cel-shaded foam bands,
and bolder ink outlines with a more saturated color palette.

https://claude.ai/code/session_01VjgP4wsHgQttTbQzP89zMA