### PR TITLE
Fix screen tearing on mobile by adding gl.clear/flush and syncing resize

### DIFF
--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -2,6 +2,8 @@ import { EngineContext, GestureEvent } from './types';
 import { InputManager } from './InputManager';
 import { Plugin } from '../plugin/Plugin';
 
+const MAX_DT = 0.1; // Cap dt at 100ms to prevent animation jumps after tab switches
+
 export class Engine {
   private canvas: HTMLCanvasElement;
   private gl: WebGL2RenderingContext;
@@ -20,9 +22,10 @@ export class Engine {
     if (!gl) throw new Error('WebGL2 not supported');
     this.gl = gl;
 
+    gl.clearColor(0, 0, 0, 1);
+
     this.input = new InputManager(this.canvas, this.onGesture);
-    window.addEventListener('resize', this.resize);
-    this.resize();
+    this.checkResize();
 
     this.lastFrameTime = performance.now() / 1000;
     this.startTime = this.lastFrameTime;
@@ -58,26 +61,50 @@ export class Engine {
 
   private loop = (nowMs: number) => {
     const now = nowMs / 1000;
-    const dt = now - this.lastFrameTime;
+    const dt = Math.min(now - this.lastFrameTime, MAX_DT);
     this.lastFrameTime = now;
 
+    const gl = this.gl;
+
+    // Check for resize at the top of the frame so that any buffer clear
+    // from setting canvas.width/height is immediately followed by a render,
+    // preventing the compositor from ever seeing a cleared-but-unrendered buffer.
+    const resized = this.checkResize();
+
     if (this.activePlugin) {
+      if (resized && this.activePlugin.resize) {
+        this.activePlugin.resize(this.buildContext(dt));
+      }
+
+      // Clear before rendering: on tile-based mobile GPUs (Mali, Adreno, Apple),
+      // this tells the GPU it can discard old tile contents instead of loading
+      // them from main memory — preventing tearing from mid-writeback compositor reads.
+      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+
       this.activePlugin.render(this.buildContext(dt));
+
+      // Flush the command queue so the GPU starts processing before the
+      // compositor reads the buffer at vsync.
+      gl.flush();
     }
 
     this.rafId = requestAnimationFrame(this.loop);
   };
 
-  private resize = () => {
+  private checkResize(): boolean {
     const dpr = window.devicePixelRatio || 1;
-    const w = this.canvas.clientWidth * dpr;
-    const h = this.canvas.clientHeight * dpr;
+    const w = Math.round(this.canvas.clientWidth * dpr);
+    const h = Math.round(this.canvas.clientHeight * dpr);
+    if (w === 0 || h === 0) return false;
     if (this.canvas.width !== w || this.canvas.height !== h) {
       this.canvas.width = w;
       this.canvas.height = h;
       this.gl.viewport(0, 0, w, h);
+      return true;
     }
-  };
+    return false;
+  }
 
   destroy() {
     cancelAnimationFrame(this.rafId);
@@ -85,6 +112,5 @@ export class Engine {
       this.activePlugin.destroy(this.buildContext(0));
     }
     this.input.destroy();
-    window.removeEventListener('resize', this.resize);
   }
 }

--- a/src/plugin/Plugin.ts
+++ b/src/plugin/Plugin.ts
@@ -6,4 +6,5 @@ export interface Plugin {
   render(ctx: EngineContext): void;
   destroy(ctx: EngineContext): void;
   onGesture?(ctx: EngineContext, event: GestureEvent): void;
+  resize?(ctx: EngineContext): void;
 }

--- a/src/plugins/laser-bird/index.ts
+++ b/src/plugins/laser-bird/index.ts
@@ -87,6 +87,20 @@ export class LaserBirdPlugin implements Plugin {
     });
   }
 
+  resize(ctx: EngineContext) {
+    const { gl } = ctx;
+
+    // Recreate scene FBO at new canvas size
+    gl.deleteFramebuffer(this.sceneFBO.fbo);
+    gl.deleteTexture(this.sceneFBO.tex);
+    this.sceneFBO = this.createFBO(gl, ctx.width, ctx.height);
+
+    // Resize bloom FBO at half res
+    const bw = Math.floor(ctx.width * BLOOM_SCALE);
+    const bh = Math.floor(ctx.height * BLOOM_SCALE);
+    this.bloomFBO.resize(gl, bw, bh);
+  }
+
   render(ctx: EngineContext) {
     const { gl } = ctx;
     gl.bindVertexArray(this.vao);

--- a/src/plugins/ripple-drop/index.ts
+++ b/src/plugins/ripple-drop/index.ts
@@ -74,6 +74,13 @@ export class RippleDropPlugin implements Plugin {
     });
   }
 
+  resize(ctx: EngineContext) {
+    const { gl } = ctx;
+    const simW = Math.floor(ctx.width * SIM_SCALE);
+    const simH = Math.floor(ctx.height * SIM_SCALE);
+    this.fbo.resize(gl, simW, simH);
+  }
+
   render(ctx: EngineContext) {
     const { gl } = ctx;
 

--- a/src/plugins/turing-patterns/index.ts
+++ b/src/plugins/turing-patterns/index.ts
@@ -84,6 +84,14 @@ export class TuringPatternsPlugin implements Plugin {
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
   }
 
+  resize(ctx: EngineContext) {
+    const { gl } = ctx;
+    const simW = Math.floor(ctx.width / 2);
+    const simH = Math.floor(ctx.height / 2);
+    this.pingPong.resize(gl, simW, simH);
+    this.seedState(ctx);
+  }
+
   render(ctx: EngineContext) {
     const { gl } = ctx;
     const stepsPerFrame = 12;


### PR DESCRIPTION
On tile-based mobile GPUs (Mali, Adreno, Apple), the missing gl.clear()
forced the GPU to load stale framebuffer contents into each tile before
overwriting, and the missing gl.flush() left the command queue unsubmitted
when the compositor read at vsync — both causing intermittent tearing.

- Add gl.clear(COLOR_BUFFER_BIT) before each frame render to enable
  tile discard optimization
- Add gl.flush() after render to submit commands before compositor reads
- Move resize check from async window event into RAF loop to prevent
  the compositor from seeing a cleared-but-unrendered buffer
- Use Math.round() on canvas dimensions to avoid fractional DPR mismatch
- Clamp dt to 100ms to prevent animation jumps after tab switches
- Add optional Plugin.resize() and implement it in LaserBird,
  TuringPatterns, and RippleDrop to resize FBOs on dimension changes

https://claude.ai/code/session_013mZW5YqbdYfBMSogUtAGLh